### PR TITLE
Fixed bug in logging

### DIFF
--- a/cfde_ap/api.py
+++ b/cfde_ap/api.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-import logging
+import logging.config
 import multiprocessing
 import os
 import shutil
@@ -26,16 +26,34 @@ app.config.from_mapping(**CONFIG)
 app.url_map.strict_slashes = False
 
 # Logging setup
-logger = multiprocessing.get_logger()
-logger.setLevel(CONFIG["LOG_LEVEL"])
-logger.propagate = False
-logfile_formatter = logging.Formatter("[{asctime}] [{levelname}] {name}: {message}",
-                                      style='{',
-                                      datefmt="%Y-%m-%d %H:%M:%S")
-logfile_handler = logging.FileHandler(CONFIG["API_LOG_FILE"], mode='a')
-logfile_handler.setFormatter(logfile_formatter)
-
-logger.addHandler(logfile_handler)
+logging.config.dictConfig({
+    'version': 1,
+    'formatters': {
+        'basic': {
+            'format': "[{asctime}] [{levelname}] {name}.{funcName}-{processName}: {message}",
+            'style': '{',
+            'datefmt': "%Y-%m-%d %H:%M:%S",
+        }
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': CONFIG["LOG_LEVEL"],
+            'formatter': 'basic',
+        },
+        'logfile': {
+            'class': 'logging.FileHandler',
+            'level': CONFIG["LOG_LEVEL"],
+            'mode': 'a',
+            'filename': CONFIG["API_LOG_FILE"],
+            'formatter': 'basic',
+        }
+    },
+    'loggers': {
+        'cfde_ap': {'level': 'DEBUG', 'handlers': ['console', 'logfile']},
+    },
+})
+logger = logging.getLogger(__name__)
 
 logger.info("\n\n==========CFDE Action Provider started==========\n")
 


### PR DESCRIPTION
Logging in actions.py wasn't properly being logged to file. This was
due to multiple loggers being in use -- the main log used the log
from multiprocessing and actions.py used its own.

In essence, the multiprocessing log appends $process to the log output,
so I setup logging to use the cfde_ap logger instead and added $process
to it. This way, the entire cfde_ap package logs properly and also
includes different process_ids in the logfiles