### PR TITLE
Fix flow deriva

### DIFF
--- a/cfde_ap/actions.py
+++ b/cfde_ap/actions.py
@@ -57,9 +57,15 @@ def deriva_ingest(servername, archive_url, deriva_webauthn_user,
     submission.ingest()
 
     md = registry.get_datapackage(submission_id)
+    success = md["status"] == DERIVA_INGEST_SUCCESS
     return {
-        "success": md["status"] == DERIVA_INGEST_SUCCESS,
-        "error": md["diagnostics"],
+        # status must be a valid automate status ['SUCCEEDED', 'FAILED', 'ACTIVE', 'INACTIVE']
+        "status": "SUCCEEDED" if success else "FAILED",
+        # Note: The automate flow expects an error to be False if there are no errors.
+        # Below ensures in any falsy value from the registry to set error=False so
+        # Automate knows there are no errors.
+        "error": md.get('diagnostics') or False,
+        "message": "DERIVA ingest successful" if success else "",
         "submission_id": submission_id,
-        "catalog_url": md["review_browse_url"]
+        "submission_link": md["review_browse_url"]
     }

--- a/cfde_ap/api.py
+++ b/cfde_ap/api.py
@@ -287,66 +287,33 @@ def cancel_action(action_id):
 
 
 def action_ingest(action_id, url, deriva_webauthn_user, globus_ep=None, servername=None, dcc_id=None):
-    # Download ingest BDBag
-    # Excessive try-except blocks because there's (currently) no process management;
-    # if the action fails, it needs to always self-report failure
-
     if not servername:
         servername = CONFIG["DEFAULT_SERVER_NAME"]
 
-    url = transfer.move_to_protected_location(url, action_id, dcc_id)
-
-    # Ingest into Deriva
-    logger.debug(f"{action_id}: Ingesting into Deriva")
-    try:
-        ingest_res = actions.deriva_ingest(servername, url, deriva_webauthn_user,
-                                           dcc_id=dcc_id, globus_ep=globus_ep, action_id=action_id)
-        if not ingest_res["success"]:
-            error_status = {
-                "status": "FAILED",
-                "details": {
-                    "error": f"Unable to ingest to DERIVA: {ingest_res.get('error')}"
-                }
-            }
-            utils.update_action_status(TBL, action_id, error_status)
-            return
-        submission_id = ingest_res["submission_id"]
-    except Exception as e:
-        logger.exception(e)
-        error_status = {
-            "status": "FAILED",
-            "details": {
-                "error": f"Error ingesting to DERIVA: {str(e)}"
-            }
-        }
-        logger.error(f"{action_id}: Error ingesting to DERIVA: {repr(e)}")
-        try:
-            utils.update_action_status(TBL, action_id, error_status)
-        except Exception as e2:
-            with open("ERROR.log", 'w') as out:
-                out.write(f"Error updating status on {action_id}: '{repr(e2)}'\n\n"
-                          f"After error '{repr(e)}'")
-        return
-
-    # Successful ingest
-    logger.debug(f"{action_id}: Catalog {dcc_id} populated")
+    # The flow can have unexpected failures if any of the keys in "details" below are absent.
+    # They're filled in with blank values to ensure the flow doesn't panic if we run into
+    # unforeseen circumstances.
     status = {
-        "status": "SUCCEEDED",
+        "status": "FAILED",
         "details": {
-            "submission_id": submission_id,
-            # "number_ingested": insert_count,
-            "deriva_link": ingest_res["catalog_url"],
-            "message": "DERIVA ingest successful",
-            "error": False
+            "submission_id": "",
+            "submission_link": "",
+            "message": "",
+            "error": "Failed due to unknown error"
         }
     }
     try:
-        utils.update_action_status(TBL, action_id, status)
+        logger.debug("Moving data to protected location")
+        url = transfer.move_to_protected_location(url, action_id, dcc_id)
+        logger.debug("Ingesting into Deriva")
+        ingest_res = actions.deriva_ingest(servername, url, deriva_webauthn_user,
+                                           dcc_id=dcc_id, globus_ep=globus_ep, action_id=action_id)
+        status["status"] = ingest_res.pop("status")
+        status["details"].update(ingest_res)
     except Exception as e:
-        with open("ERROR.log", 'w') as out:
-            out.write(f"Error updating status on {action_id}: '{repr(e)}'\n\n"
-                      f"After success on ID '{submission_id}'")
-
-    # Remove ingested files from disk
-    # Failed ingests are not removed, which helps debugging
-    return
+        logger.exception(e)
+        logger.error("Submission marked as FAILED due to the exception above.")
+        status["status"] = "FAILED"
+        status["error"] = f"Error ingesting to DERIVA: {str(e)}"
+    finally:
+        utils.update_action_status(TBL, action_id, status)

--- a/globus_automate/cfde_client_config.json
+++ b/globus_automate/cfde_client_config.json
@@ -24,7 +24,7 @@
             "cfde_ep_url": "https://g-3368fe.c0aba.03c0.data.globus.org"
         },
         "dev": {
-            "flow_id": "37b5fe50-9abd-47d0-b372-a5687ab8d8e6",
+            "flow_id": "44b83109-6d51-445b-8541-5e0a2bc1a4f4",
             "success_step": "SuccessState",
             "failure_step": "FailureState",
             "error_step": "ErrorState",

--- a/globus_automate/flow.py
+++ b/globus_automate/flow.py
@@ -4,13 +4,13 @@ sender_email = "cfde-submission@nih-cfde.org"
 admin_email = "nick@globus.org"
 smtp_hostname = "email-smtp.us-east-1.amazonaws.com"
 
-failure_text = ("'Your CFDE submission (' + action_id + ') failed to ingest into DERIVA "
+failure_text = ("'Your CFDE submission (' + submission_id + ') failed to ingest into DERIVA "
                 "with this error:\\n' + error")
 
-success_email_template = ("Your CFDE submission ($action_id) has been successfully ingested, "
-                          "and can be viewed here: $catalog_link \n Thank you.")
+success_email_template = ("Your CFDE submission ($submission_id) has been successfully ingested, "
+                          "and can be viewed here: $submission_link \n Thank you.")
 
-test_sub_success_template = ("Your test CFDE submission ($action_id) was successfully tested with DERIVA. "
+test_sub_success_template = ("Your test CFDE submission ($submission_id) was successfully tested with DERIVA. "
                              "No errors were encountered.")
 
 full_submission_flow_def = {
@@ -101,7 +101,7 @@ full_submission_flow_def = {
                     "operation": "ingest",
                     "globus_ep.$": "$.cfde_ep_id",
                     # "server": "demo.derivacloud.org",
-                    # "catalog_id.$": ,
+                    # "submission_id.$": ,
                     "dcc_id.$": "$.dcc_id",
                     "test_sub.$": "$.test_sub"
                 },
@@ -141,8 +141,8 @@ full_submission_flow_def = {
                     # "body_mimetype": "",
                     "body_template": success_email_template,
                     "body_variables": {
-                        "action_id.$": "$.DerivaIngestResult.details.submission_id",
-                        "catalog_link.$": "$.DerivaIngestResult.details.deriva_link"
+                        "submission_id.$": "$.DerivaIngestResult.details.submission_id",
+                        "submission_link.$": "$.DerivaIngestResult.details.submission_link"
                     },
                     "destination.$": "$._context.email",
                     # "notification_method": "",
@@ -175,23 +175,17 @@ full_submission_flow_def = {
                 "ExceptionOnActionFailure": True,
                 "Parameters": {
                     "expressions": [{
-                        "expression": "catalog_link",
+                        "expression": "submission_link",
                         "arguments": {
-                            "catalog_link.$": "$.DerivaIngestResult.details.deriva_link"
+                            "submission_link.$": "$.DerivaIngestResult.details.submission_link"
                         },
-                        "result_path": "deriva_link"
+                        "result_path": "submission_link"
                     }, {
-                        "expression": "catalog_id",
+                        "expression": ("'Submission Flow succeeded. Your submission ID is ' + str(submission_id) + "
+                                       "', and your submission can be viewed at this link: ' + submission_link"),
                         "arguments": {
-                            "catalog_id.$": "$.DerivaIngestResult.details.deriva_id"
-                        },
-                        "result_path": "deriva_id"
-                    }, {
-                        "expression": ("'Submission Flow succeeded. Your catalog ID is ' + str(catalog_id) + "
-                                       "', and your submission can be viewed at this link: ' + catalog_link"),
-                        "arguments": {
-                            "catalog_link.$": "$.DerivaIngestResult.details.deriva_link",
-                            "catalog_id.$": "$.DerivaIngestResult.details.deriva_id"
+                            "submission_link.$": "$.DerivaIngestResult.details.submission_link",
+                            "submission_id.$": "$.DerivaIngestResult.details.submission_id"
                         },
                         "result_path": "message"
                     }]
@@ -246,18 +240,6 @@ full_submission_flow_def = {
                 "ExceptionOnActionFailure": True,
                 "Parameters": {
                     "expressions": [{
-                        "expression": "catalog_link",
-                        "arguments": {
-                            "catalog_link": "None"
-                        },
-                        "result_path": "deriva_link"
-                    }, {
-                        "expression": "catalog_id",
-                        "arguments": {
-                            "catalog_id": "None"
-                        },
-                        "result_path": "deriva_id"
-                    }, {
                         "expression": "'Test Submission Flow succeeded. No DERIVA errors were encountered.'",
                         "result_path": "message"
                     }]
@@ -279,7 +261,7 @@ full_submission_flow_def = {
                     "expressions": [{
                         "expression": failure_text,
                         "arguments": {
-                            "action_id.$": "$._context.action_id",
+                            "submission_id.$": "$.DerivaIngestResult.details.submission_id",
                             "error.$": "$.DerivaIngestResult.details.error"
                         },
                         "result_path": "error"
@@ -332,10 +314,9 @@ full_submission_flow_def = {
                 "ExceptionOnActionFailure": True,
                 "Parameters": {
                     # "body_mimetype": "",
-                    "body_template.=": ("A CFDE Flow has errored. Please check the log for this Flow:\n"
-                                        "Flow instance ID: `$._context.action_id`.\n\nNOTE: The catalog "
-                                        "for this submission has not been deleted, to aid debugging. "
-                                        "Please manually delete the catalog when convenient."),
+                    "body_template.=": ("A CFDE Flow has encountered an error. Please contact your administrator "
+                                        "and provide the UUID below to aid in debugging\n"
+                                        "Flow instance ID: `$._context.action_id`.\n\n"),
                     "destination": admin_email,
                     # "notification_method": "",
                     # "notification_priority": "low",
@@ -382,9 +363,11 @@ full_submission_flow_def = {
         }
     },
     "description": ("Run the CFDE submission flow."),
-    "runnable_by": ["urn:globus:groups:id:a437abe3-c9a4-11e9-b441-0efb3ba9a670"],  # CFDE DERIVA Demo
+    # runnable_by and visible_to are dynamically set with values in each Deriva app instance
+    # when running the deploy.py script.
+    # "runnable_by": ["urn:globus:groups:id:a437abe3-c9a4-11e9-b441-0efb3ba9a670"],  # CFDE DERIVA Demo
+    # "visible_to": ["urn:globus:groups:id:a437abe3-c9a4-11e9-b441-0efb3ba9a670"]  # CFDE DERIVA Demo
     "synchronous": False,
     "title": "CFDE Submission",
     "types": ["Action", "Choice"],
-    "visible_to": ["urn:globus:groups:id:a437abe3-c9a4-11e9-b441-0efb3ba9a670"]  # CFDE DERIVA Demo
 }


### PR DESCRIPTION
These changes fix a couple different error cases we've seen when a flow results in errors:
    * The "submission id" sent through email being wrong, due to the flow fetching any action_id on the flow and not specifically the action_id used for the submission
    * The flow failing after the Deriva ingest stage due to inadequate context on the flow, which could result in emails to fail to send, such as what happened here: https://github.com/nih-cfde/submission-workflow/issues/53
    * The flow referencing an old "catalog_id" value which was previously used in the old epic1 code

I went through and simplified the code responsible for getting errors from submissions, so it should always return information for the remaining flow to finish. The submission_id should also now always be complete, or simply absent if the action provider encountered a critical failure.

Fixes for: 
* https://github.com/nih-cfde/submission-workflow/issues/53
* https://github.com/nih-cfde/submission-workflow/issues/56

Note: Issue 56 was partially fixed by separate changes, but I found an error state still included the wrong id. Should be completely fixed now. 

